### PR TITLE
Added 'DISPATCHED' status for newly spawned jobs.

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -26,7 +26,7 @@ class JobsController < ApplicationController
   # POST /jobs
   # POST /jobs.json
   def create
-    @job = Job.new(job_params.merge(worker: find_free_worker))
+    @job = Job.new(job_params.merge(worker: find_free_worker, status: "DISPATCHED"))
 
     respond_to do |format|
       if @job.save

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -11,7 +11,7 @@ class Job < ApplicationRecord
   has_one :user, through: :worker
 
   # Validations
-  validates :status, inclusion: { in: %w(UNDEFINED ERROR NORMAL\ EXECUTION) }
+  validates :status, inclusion: { in: %w(DISPATCHED UNDEFINED ERROR NORMAL\ EXECUTION) }
 
   def channel
     WebsocketRails["job.#{id}"]


### PR DESCRIPTION
### Updates
Fixes #31 by setting job status to `DISPATCHED` on spawning job.