### PR TITLE
Update healthcheck info live

### DIFF
--- a/app/controllers/job_connection_controller.rb
+++ b/app/controllers/job_connection_controller.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
 class JobConnectionController < WebsocketRails::BaseController
-  def authorize_channels
-    match = /^job\.(?<id>\w+)$/.match(message[:channel])
-    return deny_channel unless match
-
-    job = Job.find_by(id: match[:id].to_i)
-    if job && current_user && job.user == current_user
-      accept_channel job.as_json
-    else
-      deny_channel "Unauthorized"
-    end
-  end
-
   def stdout
     Rails.logger.info "Updated stdout for #{message['id']}, with stdout: #{message['stdout']}."
     job&.append_to_column("stdout", message["stdout"])

--- a/app/controllers/websocket_authentication_controller.rb
+++ b/app/controllers/websocket_authentication_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class WebsocketAuthenticationController < WebsocketRails::BaseController
+  def authorize_channels
+    if message[:channel].start_with?("job")
+      authorize_job
+    elsif message[:channel].start_with?("worker_info")
+      authorize_worker_info
+    else
+      deny_channel
+    end
+  end
+
+  private
+
+  def authorize_job
+    match = /^job\.(?<id>\w+)$/.match(message[:channel])
+    return deny_channel unless match
+
+    job = Job.find_by(id: match[:id].to_i)
+    if job && current_user && job.user == current_user
+      accept_channel job.as_json
+    else
+      deny_channel
+    end
+  end
+
+  def authorize_worker_info
+    Rails.logger.info("Authorizing worker info")
+    match = /^worker_info\.(?<id>\w+)$/.match(message[:channel])
+    Rails.logger.info(match.inspect)
+    return deny_channel unless match
+
+    worker = Worker.find_by(id: match[:id].to_i)
+    if worker && current_user && worker.user == current_user
+      accept_channel
+    else
+      deny_channel
+    end
+  end
+end

--- a/app/controllers/websocket_authentication_controller.rb
+++ b/app/controllers/websocket_authentication_controller.rb
@@ -14,26 +14,20 @@ class WebsocketAuthenticationController < WebsocketRails::BaseController
   private
 
   def authorize_job
-    match = /^job\.(?<id>\w+)$/.match(message[:channel])
-    return deny_channel unless match
-
-    job = Job.find_by(id: match[:id].to_i)
-    if job && current_user && job.user == current_user
-      accept_channel job.as_json
-    else
-      deny_channel
-    end
+    authorize_by_id("job", Job)
   end
 
   def authorize_worker_info
-    Rails.logger.info("Authorizing worker info")
-    match = /^worker_info\.(?<id>\w+)$/.match(message[:channel])
-    Rails.logger.info(match.inspect)
+    authorize_by_id("worker_info", Worker)
+  end
+
+  def authorize_by_id(channel_prefix, klass)
+    match = /^#{channel_prefix}\.(?<id>\w+)$/.match(message[:channel])
     return deny_channel unless match
 
-    worker = Worker.find_by(id: match[:id].to_i)
-    if worker && current_user && worker.user == current_user
-      accept_channel
+    instance = klass.find_by(id: match[:id].to_i)
+    if instance && current_user && instance.user == current_user
+      accept_channel instance.as_json
     else
       deny_channel
     end

--- a/app/controllers/worker_connection_controller.rb
+++ b/app/controllers/worker_connection_controller.rb
@@ -8,7 +8,8 @@ class WorkerConnectionController < WebsocketRails::BaseController
 
   def healthcheck
     Rails.logger.info "Set healthcheck for worker: #{message['id']}."
-    worker.update(message.slice(*worker_healthcheck_params))
+    worker&.update(message.slice(*worker.healthcheck_params))
+    worker&.info_channel&.trigger(:healthcheck, worker.health_info, namespace: :worker_info)
   end
 
   private
@@ -33,9 +34,5 @@ class WorkerConnectionController < WebsocketRails::BaseController
 
     # Returns nil if the worker does not belong to the current 'worker_user'
     @worker.user != worker_user ? nil : @worker
-  end
-
-  def worker_healthcheck_params
-    %w(cpu_count load total_memory available_memory total_disk used_disk free_disk)
   end
 end

--- a/app/javascript/packs/workers.jsx
+++ b/app/javascript/packs/workers.jsx
@@ -76,6 +76,17 @@ class Workers extends React.Component {
     };
 
     this.selectJob = this.selectJob.bind(this);
+    this.healthcheck = this.healthcheck.bind(this);
+  }
+
+  healthcheck(data) {
+    console.log('got healthcheck');
+    console.log(data);
+    this.setState(state => {
+      const worker = state.workers.find(w => w.id == data.id);
+      Object.assign(worker, data);
+      return state;
+    });
   }
 
   selectJob(id) {
@@ -137,7 +148,13 @@ class Workers extends React.Component {
           this.selectJob(firstWithJobs.jobs[0].id);
         }
 
-        console.log(json)
+        json.workers.forEach(w => {
+          console.log(`worker_info.${w.id}`);
+          const channel = dispatcher.subscribe_private(`worker_info.${w.id}`);
+          channel.bind('worker_info.healthcheck', this.healthcheck);
+        });
+
+        console.log(json);
       })
       .catch(e => console.error(e));
   }

--- a/app/models/worker.rb
+++ b/app/models/worker.rb
@@ -29,6 +29,8 @@ class Worker < ApplicationRecord
     WebsocketRails["worker_info.#{id}"]
   end
 
+  private
+
   def make_info_channel
     info_channel.make_private
   end

--- a/app/models/worker.rb
+++ b/app/models/worker.rb
@@ -3,6 +3,7 @@
 class Worker < ApplicationRecord
   # Callbacks
   before_commit :update_heartbeat
+  after_create :make_info_channel
 
   # Associations
   belongs_to :user
@@ -12,7 +13,23 @@ class Worker < ApplicationRecord
     update(last_heartbeat: Time.zone.now)
   end
 
+  def healthcheck_params
+    %w(cpu_count load total_memory available_memory total_disk used_disk free_disk)
+  end
+
+  def health_info
+    as_json.slice("id", *healthcheck_params)
+  end
+
   def channel
     WebsocketRails["worker.#{id}"]
+  end
+
+  def info_channel
+    WebsocketRails["worker_info.#{id}"]
+  end
+
+  def make_info_channel
+    info_channel.make_private
   end
 end

--- a/config/events.rb
+++ b/config/events.rb
@@ -2,7 +2,7 @@
 
 WebsocketRails::EventMap.describe do
   namespace :websocket_rails do
-    subscribe :subscribe_private, to: JobConnectionController, with_method: :authorize_channels
+    subscribe :subscribe_private, to: WebsocketAuthenticationController, with_method: :authorize_channels
   end
 
   namespace :job do


### PR DESCRIPTION
- moves all websocket authentication into its own controller
- Makes a second websocket channel for each worker. `worker.${id}` is to send spawn requests to the worker itself, `worker_info.${id}` is to subscribe to health check updates on the ui.