### PR TITLE
Support killing workers, soft-delete serverside

### DIFF
--- a/app/assets/stylesheets/workers.scss
+++ b/app/assets/stylesheets/workers.scss
@@ -16,6 +16,10 @@
   flex-direction: column;
   background-color: $light-shade;
 
+  &.deleted {
+    opacity: 0.8;
+  }
+
   .section {
     display: flex;
     flex-wrap: wrap;

--- a/app/assets/stylesheets/workers.scss
+++ b/app/assets/stylesheets/workers.scss
@@ -15,9 +15,16 @@
   display: flex;
   flex-direction: column;
   background-color: $light-shade;
+  position: relative;
 
   &.deleted {
-    opacity: 0.8;
+    opacity: 0.3;
+  }
+
+  button.delete {
+    position: absolute;
+    top: 10px;
+    right: 10px;
   }
 
   .section {

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -76,11 +76,11 @@ class JobsController < ApplicationController
       .workers
       .active
       .joins(
-          "left outer join jobs on jobs.worker_id = workers.id " +
-          "and jobs.return_code is null"
+          "LEFT JOIN jobs ON jobs.worker_id = workers.id " +
+          "AND jobs.return_code IS NULL"
       )
       .group("workers.id")
-      .order("count(distinct jobs.id) asc")
+      .order("COUNT(DISTINCT jobs.id) ASC")
       .first
   end
 

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -74,7 +74,11 @@ class JobsController < ApplicationController
   def find_free_worker
     current_user
       .workers
-      .joins("left outer join jobs on jobs.worker_id = workers.id")
+      .active
+      .joins(
+          "left outer join jobs on jobs.worker_id = workers.id " +
+          "and jobs.return_code is null"
+      )
       .group("workers.id")
       .order("count(distinct jobs.id) asc")
       .first

--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -57,7 +57,7 @@ class WorkersController < ApplicationController
   # DELETE /workers/1
   # DELETE /workers/1.json
   def destroy
-    @worker.destroy
+    @worker.soft_delete!
     respond_to do |format|
       format.html { redirect_to workers_url, notice: "Worker was successfully destroyed." }
       format.json { head :no_content }

--- a/app/javascript/packs/workers.jsx
+++ b/app/javascript/packs/workers.jsx
@@ -54,7 +54,7 @@ class Worker extends React.Component {
 
   render() {
     return (
-      <div className='worker'>
+      <div className={`worker ${this.props.deleted ? 'deleted' : ''}`}>
         <h3>{this.props.id}</h3>
         <div className='section info'>
           {Object.keys(this.INFO_PROPS).map(this.renderInfoProp)}

--- a/app/javascript/packs/workers.jsx
+++ b/app/javascript/packs/workers.jsx
@@ -25,6 +25,11 @@ class Worker extends React.Component {
 
     this.renderInfoProp = this.renderInfoProp.bind(this);
     this.renderJob = this.renderJob.bind(this);
+    this.deleteWorker = this.deleteWorker.bind(this);
+  }
+
+  deleteWorker() {
+    this.props.deleteWorker(this.props.id);
   }
 
   renderInfoProp(prop) {
@@ -55,6 +60,11 @@ class Worker extends React.Component {
   render() {
     return (
       <div className={`worker ${this.props.deleted ? 'deleted' : ''}`}>
+        {this.props.deleted ? null :
+          <button className='delete button button--secondary' onClick={this.deleteWorker}>
+            Delete
+          </button>
+        }
         <h3>{this.props.id}</h3>
         <div className='section info'>
           {Object.keys(this.INFO_PROPS).map(this.renderInfoProp)}
@@ -77,6 +87,7 @@ class Workers extends React.Component {
 
     this.selectJob = this.selectJob.bind(this);
     this.healthcheck = this.healthcheck.bind(this);
+    this.deleteWorker = this.deleteWorker.bind(this);
   }
 
   healthcheck(data) {
@@ -159,6 +170,28 @@ class Workers extends React.Component {
       .catch(e => console.error(e));
   }
 
+  deleteWorker(id) {
+    const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    fetch(`/workers/${id}.json`, {
+      method: 'DELETE',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Cache': 'no-cache',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': token
+      },
+      credentials: 'same-origin'
+    })
+      .then(
+        () => this.setState(state => {
+          state.workers.find(w => w.id == id).deleted = true;
+          return state;
+        })
+      )
+      .catch(e => console.error(e));
+  }
+
   render() {
     if (!this.state.workers) return <p>Loading...</p>;
 
@@ -172,7 +205,9 @@ class Workers extends React.Component {
                 {...w}
                 jobTypes={this.state.jobTypes}
                 selected={this.state.selected}
-                selectJob={this.selectJob} />
+                selectJob={this.selectJob}
+                deleteWorker={this.deleteWorker}
+              />
             )}
           </div>
         </div>

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -13,6 +13,9 @@ class Job < ApplicationRecord
   # Validations
   validates :status, inclusion: { in: %w(DISPATCHED UNDEFINED ERROR NORMAL\ EXECUTION) }
 
+  # Scopes
+  default_scope { order("(return_code IS NULL) ASC, created_at DESC") }
+
   def channel
     WebsocketRails["job.#{id}"]
   end

--- a/app/views/job_types/index.html.slim
+++ b/app/views/job_types/index.html.slim
@@ -24,8 +24,10 @@ table
         td = link_to 'Edit', edit_job_type_path(job_type)
         td = button_to 'Destroy', job_type, method: :delete
         td
-          - if current_user.workers.any?
+          - if current_user.workers.active.any?
             = button_to 'Spawn', { controller: "jobs", action: "create", job: { job_type_id: job_type.id } }, method: :post
+          - elsif current_user.workers.any?
+            button(disabled=true) Wait for one of your workers to come online to spawn this job.
           - else
             button(disabled=true) Create a worker to spawn this job
 

--- a/app/views/workers/_worker.json.jbuilder
+++ b/app/views/workers/_worker.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! worker, :id, :last_heartbeat, :created_at, :updated_at, :cpu_count, :load, :total_memory, :available_memory, :total_disk, :used_disk, :free_disk, :jobs
+json.extract! worker, :id, :last_heartbeat, :created_at, :updated_at, :cpu_count, :load, :total_memory, :available_memory, :total_disk, :used_disk, :free_disk, :jobs, :deleted

--- a/db/migrate/20171031155638_add_deleted_to_workers.rb
+++ b/db/migrate/20171031155638_add_deleted_to_workers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeletedToWorkers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :workers, :deleted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171027164742) do
+ActiveRecord::Schema.define(version: 20171031155638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,10 +110,10 @@ ActiveRecord::Schema.define(version: 20171027164742) do
   end
 
   create_table "workers", force: :cascade do |t|
-    t.integer  "user_id",          null: false
+    t.integer  "user_id",                          null: false
     t.datetime "last_heartbeat"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.integer  "cpu_count"
     t.float    "load"
     t.integer  "total_memory"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 20171027164742) do
     t.integer  "used_disk"
     t.integer  "free_disk"
     t.string   "slug"
+    t.boolean  "deleted",          default: false, null: false
     t.index ["slug"], name: "index_workers_on_slug", unique: true, using: :btree
     t.index ["user_id"], name: "index_workers_on_user_id", using: :btree
   end


### PR DESCRIPTION
- Adds soft-delete to workers so that you can still see finished jobs
  - Sends message to the worker when a soft-delete happens
- Updates ordering so deleted workers go last
- Updates ordering so finished jobs go last
- Updates job dispatch logic so it only assigns to workers for whom we received a healthcheck for recently, and order by the number of *active* jobs to find a free worker instead of *total* jobs