### PR TITLE
Add cwd, env to process wrapper

### DIFF
--- a/service/command_handlers/command_handler_factory.py
+++ b/service/command_handlers/command_handler_factory.py
@@ -13,7 +13,6 @@ class CommandHandlerFactory():
         if type(response) is SpawnResponse:
             # spawn a job
             logger.info("Got a spawn command")
-
             handler = SpawnCommandHandler
 
         elif type(response) is ClientConnectedResponse:

--- a/service/command_handlers/spawn_handler.py
+++ b/service/command_handlers/spawn_handler.py
@@ -16,7 +16,9 @@ class SpawnCommandHandler(CommandHandler):
         wrapper = ProcessWrapperCommand(
             command.id,
             command.script,
-            kwargs["service_host"]
+            service_host=kwargs["service_host"],
+            cwd=command.working_directory,
+            env=command.environment_variables,
         )
 
         process = await wrapper.launch_process_wrapper()

--- a/service/jobs/environ.py
+++ b/service/jobs/environ.py
@@ -1,0 +1,8 @@
+import sys
+import os
+import time
+
+for key in sys.argv[1:]:
+    val = os.environ.get(key)
+    sys.stdout.write('env variable "{}"={}\n'.format(key, val))
+

--- a/service/process_wrapper_command.py
+++ b/service/process_wrapper_command.py
@@ -1,6 +1,13 @@
 import subprocess
 import asyncio
 
+import logging
+import json
+
+logging.basicConfig()
+logger = logging.getLogger("Process Wrapper Command")
+logger.setLevel(logging.DEBUG)
+
 class NoRunningProcessException(Exception):
     pass
 
@@ -17,19 +24,22 @@ class ProcessWrapperCommand():
         self.process = None
 
     def __str__(self):
-        return 'python3 process_wrapper.py --command="{0}" --job_id={1} --service_host="{2}"'.format(self.command, self.job_id, self.service_host)
+        return ' '.join(map(str, self.get_command()));
 
     def get_command(self):
-        return ['python3', 'process_wrapper.py',
+        cmd = ['python3', 'process_wrapper.py',
                 '--command', self.command,
                 '--job_id', self.job_id,
                 '--service_host', self.service_host]
+        if self.cwd:
+            cmd.extend(['--cwd', self.cwd])
+        if self.env:
+            cmd.extend(['--env', json.dumps(self.env)])
+        return cmd
 
     async def launch_process_wrapper(self):
         process = await asyncio.create_subprocess_exec(
             *list(map(str, self.get_command())),
-            cwd=self.cwd if self.cwd != "" else None,
-            env=self.env
         )
         self.process = process
         return process


### PR DESCRIPTION
Fix #53 
Fix #51 

Add support for changing working directory within the process wrapper before executing the job, as well as configuring the environment of the executed job.

process_wrapper.py has two new command line arguments:
* --cwd is the working directory as a string
* --env is a json string containing a single map of environment variable names and values