### PR TITLE
Remove duplicate name constraint from job types

### DIFF
--- a/db/migrate/20171104233203_remove_index_names_from_job_types.rb
+++ b/db/migrate/20171104233203_remove_index_names_from_job_types.rb
@@ -1,0 +1,5 @@
+class RemoveIndexNamesFromJobTypes < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :job_types, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 20171104235401) do
     t.integer  "user_id"
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
-    t.index ["name"], name: "index_job_types_on_name", unique: true, using: :btree
     t.index ["user_id"], name: "index_job_types_on_user_id", using: :btree
   end
 


### PR DESCRIPTION
I didn't make them unique per user instead of globally, I just removed the constraint. If a user names two job types the same thing, we can call that their own fault