### PR TITLE
Kill non responsive processes

### DIFF
--- a/service/health_check/health_check_coroutine.py
+++ b/service/health_check/health_check_coroutine.py
@@ -4,7 +4,6 @@ import asyncio
 from health_check.server_health import ServerHealth
 from websocket_requests import HealthCommand
 
-logging.basicConfig()
 logger = logging.getLogger("HealthCheckCoroutine")
 logger.setLevel(logging.DEBUG)
 

--- a/service/jobs/sisiphus.py
+++ b/service/jobs/sisiphus.py
@@ -1,0 +1,15 @@
+import time
+import sys
+import signal
+
+sys.stdout.write("starting\n")
+
+def term_handler(signum, frame):
+    sys.stdout.write("I dont wanna DIE. You cant kill me.\n")
+
+signal.signal(signal.SIGTERM, term_handler)
+
+while True:
+    sys.stdout.write("Life is sad\n")
+    sys.stdout.flush()
+    time.sleep(1)

--- a/service/process_wrapper.py
+++ b/service/process_wrapper.py
@@ -13,9 +13,17 @@ from argparse import ArgumentParser
 import websockets
 from websocket_requests.job_commands import JobStdout, JobStderr, JobReturnCode
 
-logging.basicConfig()
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('ProcessWrapper')
 logger.setLevel(logging.DEBUG)
+
+
+# TO TEST KILL FUNCTIONALITY
+# This block of code will prevent this process from dying.
+# def term_handler(signum, frame):
+    # sys.stdout.write("I dont wanna DIE. You cant kill me.\n")
+# signal.signal(signal.SIGTERM, term_handler)
+
 
 class ProcessWrapper():
 
@@ -33,7 +41,7 @@ class ProcessWrapper():
             async with websockets.connect(arguments.service_host) as websocket:
                 logger.debug('Successfully connected to server.')
 
-                logger.debug('Starting job: {}'.format(self.command))
+                logger.info('Starting job: {}'.format(self.command))
                 process = await asyncio.create_subprocess_shell(
                         self.command,
                         #stdin=asyncio.subprocess.PIPE,
@@ -171,7 +179,7 @@ if __name__ == '__main__':
         job_id=arguments.job_id,
         command=arguments.command,
         cwd=arguments.cwd,
-        env=json.loads(arguments.env),
+        env=json.loads(arguments.env) if arguments.env else None,
     )
     loop = asyncio.get_event_loop()
 

--- a/service/process_wrapper_command.py
+++ b/service/process_wrapper_command.py
@@ -43,7 +43,7 @@ class ProcessWrapperCommand():
         self.process = process
         return process
 
-    async def kill_process(self):
+    def kill_process(self):
         """
         Kills a process.
         """
@@ -51,10 +51,6 @@ class ProcessWrapperCommand():
             raise NoRunningProcessException()
 
         self.process.send_signal(subprocess.signal.SIGKILL)
-
-        # this should be instant
-        await self.process.wait()
-
 
     async def stop_process(self):
         """

--- a/service/process_wrapper_command.py
+++ b/service/process_wrapper_command.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import json
 
-logging.basicConfig()
 logger = logging.getLogger("Process Wrapper Command")
 logger.setLevel(logging.DEBUG)
 

--- a/service/websocket_requests/health_command.py
+++ b/service/websocket_requests/health_command.py
@@ -5,5 +5,5 @@ class HealthCommand(Command):
         temp_dict = health_dict
         temp_dict.update({"key": api_key})
         temp_dict.update({"id": id})
-        super(HealthCommand, self).__init__("worker.health_check", temp_dict)
+        super(HealthCommand, self).__init__("worker.healthcheck", temp_dict)
 


### PR DESCRIPTION
When we receive a kill command from the server, we try to kill pending children (so they don't become orphans). If this kill timed out before and the processes ignored SIGTERM, they would still become orphans of init. Now I set a timeout and after 10 seconds, SIGKILL them.