### PR TITLE
Added event action for spawning user job.

### DIFF
--- a/app/controllers/job_connection_controller.rb
+++ b/app/controllers/job_connection_controller.rb
@@ -32,6 +32,6 @@ class JobConnectionController < WebsocketRails::BaseController
   end
 
   def dispatch_job_events!
-    job.event_dispatcher.dispatch!
+    job.event_dispatcher.dispatch!(current_user)
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -72,16 +72,7 @@ class JobsController < ApplicationController
   end
 
   def find_free_worker
-    current_user
-      .workers
-      .active
-      .joins(
-          "LEFT JOIN jobs ON jobs.worker_id = workers.id " +
-          "AND jobs.return_code IS NULL"
-      )
-      .group("workers.id")
-      .order("COUNT(DISTINCT jobs.id) ASC")
-      .first
+    current_user.workers.assignment_order.first
   end
 
   def job_params

--- a/app/models/delayed_email.rb
+++ b/app/models/delayed_email.rb
@@ -4,10 +4,10 @@
 # EventAction derived class using Single Table Inheritance
 #
 # Public interface:
-#   run!
+#   run!(user)
 #
 class DelayedEmail < EventAction
-  def run!
+  def run!(_user)
     MailWorker.perform_in(3.hours, job_type)
   end
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -4,10 +4,10 @@
 # EventAction derived class using Single Table Inheritance
 #
 # Public interface:
-#   run!
+#   run!(user)
 #
 class Email < EventAction
-  def run!
+  def run!(_user)
     ErrorMailer.email(job_type).deliver
   end
 end

--- a/app/models/event_action.rb
+++ b/app/models/event_action.rb
@@ -11,7 +11,8 @@ class EventAction < ApplicationRecord
 
   PROPERTIES = %i(job_type_id email_address webhook_url webhook_body type)
 
-  def run!
+  def run!(_user)
+    raise NotImplementedError, "EventAction::run!(user) is a pure virtual method."
   end
 
   def owned_job_type?

--- a/app/models/event_dispatcher.rb
+++ b/app/models/event_dispatcher.rb
@@ -14,7 +14,7 @@ class EventDispatcher < ApplicationRecord
     return if triggered || !event_receiver.trigger_condition_met?
 
     # Run each of the event actions corresponding to the job
-    job.event_actions.each { |job| job.run!(user) }
+    job.event_actions.each { |action| action.run!(user) }
 
     # Set the record to be triggered
     self.triggered = true

--- a/app/models/event_dispatcher.rb
+++ b/app/models/event_dispatcher.rb
@@ -2,19 +2,19 @@
 
 class EventDispatcher < ApplicationRecord
   # Associations
-  belongs_to :job
   belongs_to :event_receiver
+  belongs_to :job
 
   # Validations
   validates :triggered, presence: true
 
-  def dispatch!(job)
+  def dispatch!(user)
     # 1) Don't perform an action if it has already been performed on the rising edge trigger
     # 2) Only perform the dispatch if the event_receiver's trigger condition has been met
     return if triggered || !event_receiver.trigger_condition_met?
 
     # Run each of the event actions corresponding to the job
-    job.event_actions.each(&:run!)
+    job.event_actions.each { |job| job.run!(user) }
 
     # Set the record to be triggered
     self.triggered = true

--- a/app/models/spawn_job.rb
+++ b/app/models/spawn_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#
+# EventAction derived class using Single Table Inheritance
+#
+# Public interface:
+#   run!(user)
+#
+class SpawnJob < EventAction
+  def run!(user)
+    Job.new(job_params.merge(worker: user.workers.assignment_order.first, status: "DISPATCHED"))
+  end
+end

--- a/app/models/spawn_job.rb
+++ b/app/models/spawn_job.rb
@@ -8,6 +8,6 @@
 #
 class SpawnJob < EventAction
   def run!(user)
-    Job.new(job_params.merge(worker: user.workers.assignment_order.first, status: "DISPATCHED"))
+    Job.new(job_type_id: job_type.id, worker: user.workers.assignment_order.first, status: "DISPATCHED")
   end
 end

--- a/app/models/spawn_job.rb
+++ b/app/models/spawn_job.rb
@@ -8,6 +8,6 @@
 #
 class SpawnJob < EventAction
   def run!(user)
-    Job.new(job_type_id: job_type.id, worker: user.workers.assignment_order.first, status: "DISPATCHED")
+    Job.new(job_type: job_type, worker: user.workers.assignment_order.first, status: "DISPATCHED")
   end
 end


### PR DESCRIPTION
Closes #73 

### Changes

- Updated the public interface for `event_actions` to take in a `user` parameter, as per discussion with @davepagurek.
- Can spawn jobs to run instantaneously when `run!(user)` is invoked.