### PR TITLE
Added scheduled job worker for ScheduledReceiver.

### DIFF
--- a/app/models/scheduled_receiver.rb
+++ b/app/models/scheduled_receiver.rb
@@ -1,10 +1,20 @@
 # frozen_string_literal: true
 
 class ScheduledReceiver < EventReceiver
+  # Callbacks
+  after_create :schedule_job
+
+  # Validations
   validates :start_time, presence: true
 
-  # Only called from sidekiq job, trigger condition will always be met
+  # Sidekiq job scheduled after_create => trigger condition will always be met
   def trigger_condition_met?(_job)
     true
+  end
+
+  private
+
+  def schedule_job
+    JobWorker.perform_at(start_time.from_now, id)
   end
 end

--- a/app/models/scheduled_receiver.rb
+++ b/app/models/scheduled_receiver.rb
@@ -15,6 +15,6 @@ class ScheduledReceiver < EventReceiver
   private
 
   def create_scheduled_job!
-    JobWorker.perform_at(start_time.from_now, id)
+    ScheduledWorker.perform_at(start_time.from_now, id)
   end
 end

--- a/app/models/scheduled_receiver.rb
+++ b/app/models/scheduled_receiver.rb
@@ -2,7 +2,7 @@
 
 class ScheduledReceiver < EventReceiver
   # Callbacks
-  after_create :schedule_job
+  after_create :create_scheduled_job!
 
   # Validations
   validates :start_time, presence: true
@@ -14,7 +14,7 @@ class ScheduledReceiver < EventReceiver
 
   private
 
-  def schedule_job
+  def create_scheduled_job!
     JobWorker.perform_at(start_time.from_now, id)
   end
 end

--- a/app/workers/job_worker.rb
+++ b/app/workers/job_worker.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class JobWorker
+  include Sidekiq::Worker
+  attr_reader :receiver
+
+  def perform(id)
+    @receiver = Receiver.find_by(id)
+    return unless receiver
+    schedule_job
+  end
+
+  private
+
+  def schedule_job
+    if worker
+      @job = Job.new(job_type: receiver.job_type, worker: worker, status: "DISPATCHED")
+    else
+      JobWorker.perform_at(receiver.start_time.from_now, id)
+    end
+  end
+
+  def worker
+    receiver
+      &.user
+      &.workers
+      &.assignment_order
+      &.first
+  end
+end

--- a/app/workers/job_worker.rb
+++ b/app/workers/job_worker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class JobWorker
+class ScheduledWorker
   include Sidekiq::Worker
   attr_reader :receiver
 
@@ -16,7 +16,7 @@ class JobWorker
     if worker
       @job = Job.new(job_type: receiver.job_type, worker: worker, status: "DISPATCHED")
     else
-      JobWorker.perform_at(receiver.start_time.from_now, id)
+      ScheduledWorker.perform_at(receiver.start_time.from_now, id)
     end
   end
 


### PR DESCRIPTION
### Changes
- Added an `after_create :schedule_job` callback for the `ScheduledReceiver` event receiver, which creates a sidekiq worker to spawn a job after some interval of time.
- If no free workers exist, the job will reperform after the same `start_time` indefinitely, until a worker becomes available, or the receiver is deleted.