### PR TITLE
Added 'RETRY_TIME' to worker model.

### DIFF
--- a/app/models/scheduled_receiver.rb
+++ b/app/models/scheduled_receiver.rb
@@ -15,6 +15,6 @@ class ScheduledReceiver < EventReceiver
   private
 
   def create_scheduled_job!
-    ScheduledWorker.perform_at(start_time.from_now, id)
+    ScheduledWorker.perform_at(Worker::RETRY_TIME.from_now, id)
   end
 end

--- a/app/models/worker.rb
+++ b/app/models/worker.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Worker < ApplicationRecord
+  # Constants
+  RETRY_TIME = 3_600
+
   # Callbacks
   before_commit :update_heartbeat
   after_create :make_info_channel

--- a/app/workers/scheduled_worker.rb
+++ b/app/workers/scheduled_worker.rb
@@ -16,7 +16,7 @@ class ScheduledWorker
     if worker
       @job = Job.new(job_type: receiver.job_type, worker: worker, status: "DISPATCHED")
     else
-      ScheduledWorker.perform_at(receiver.start_time.from_now, id)
+      ScheduledWorker.perform_at(Worker::RETRY_TIME.from_now, id)
     end
   end
 


### PR DESCRIPTION
Closes #75 

### Changes
- Don't wait 2017 years until re-running the next job, just wait one hour instead.