### PR TITLE
Fix job spawning

### DIFF
--- a/app/assets/stylesheets/event_receivers.scss
+++ b/app/assets/stylesheets/event_receivers.scss
@@ -32,7 +32,7 @@
   &.dirty {
     border: 1px solid $accent;
 
-    .controls {
+    & > .controls {
       transform: translateX(0);
       opacity: 1;
     }

--- a/app/controllers/job_connection_controller.rb
+++ b/app/controllers/job_connection_controller.rb
@@ -32,6 +32,6 @@ class JobConnectionController < WebsocketRails::BaseController
   end
 
   def dispatch_job_events!
-    job.event_dispatcher.dispatch!(current_user)
+    job.event_dispatchers.each(&:dispatch!)
   end
 end

--- a/app/javascript/packs/event_actions.jsx
+++ b/app/javascript/packs/event_actions.jsx
@@ -98,14 +98,14 @@ class EventAction extends React.Component {
 
   renderForm() {
     switch (this.props.type) {
-      case 'EmailAction':
+      case 'Email':
         return (
           <div className='field'>
             <label>Email</label>
             <input type='text' value={this.props.email_address || ''} onChange={this.updateEmailAddress} />
           </div>
         );
-      case 'WebhookAction':
+      case 'Webhook':
         return (
           <div>
             <div className='field'>
@@ -118,7 +118,7 @@ class EventAction extends React.Component {
             </div>
           </div>
         );
-      case 'SpawnJobAction':
+      case 'SpawnJob':
         return (
           <select value={`${this.props.job_type_id}`} onChange={this.updateJobTypeId}>
           {this.props.job_types.map(
@@ -143,9 +143,9 @@ class EventAction extends React.Component {
           <div className='field'>
             <label>Type:</label>
             <select value={this.props.type} onChange={this.updateType}>
-              <option value='EmailAction'>Send an email</option>
-              <option value='WebhookAction'>Send a webhook</option>
-              <option value='SpawnJobAction'>Spawn another job</option>
+              <option value='Email'>Send an email</option>
+              <option value='Webhook'>Send a webhook</option>
+              <option value='SpawnJob'>Spawn another job</option>
             </select>
           </div>
           {this.renderForm()}

--- a/app/javascript/packs/event_receivers.jsx
+++ b/app/javascript/packs/event_receivers.jsx
@@ -112,11 +112,8 @@ class EventReceivers extends React.Component {
       .event_actions[actionIndex]
       .id;
 
-      console.log(this.state.event_receivers[receiverIndex]
-      .event_actions[actionIndex])
-
     let [url, method] = (
-      (id === null) ? ['/event_actions', 'POST'] : [`/event_actions/${id}.json`, 'PATCH']
+      (id === null) ? ['/event_actions.json', 'POST'] : [`/event_actions/${id}.json`, 'PATCH']
     );
 
     fetch(url, {
@@ -133,7 +130,7 @@ class EventReceivers extends React.Component {
     })
       .then(res => res.json())
       .then(json => this.setState(state => {
-        state.event_receivers[receiverIndex][actionIndex] = json;
+        state.event_receivers[receiverIndex].event_actions[actionIndex] = json;
         return state;
       }))
       .catch(e => console.error(e));
@@ -146,7 +143,7 @@ class EventReceivers extends React.Component {
         .splice(actionIndex, 1);
 
       if (action.id !== null) {
-        fetch(`event_actions/${action.id}`, {
+        fetch(`event_actions/${action.id}.json`, {
           method: 'DELETE',
           headers: {
             'Accept': 'application/json',

--- a/app/models/event_action.rb
+++ b/app/models/event_action.rb
@@ -17,7 +17,7 @@ class EventAction < ApplicationRecord
   end
 
   def owned_job_type?
-    return unless job_type && job_type.user != event_action.user
+    return unless job_type && job_type.user != user
     errors.add(:job_type, "must be one of your jobs")
   end
 end

--- a/app/models/event_dispatcher.rb
+++ b/app/models/event_dispatcher.rb
@@ -5,18 +5,15 @@ class EventDispatcher < ApplicationRecord
   belongs_to :event_receiver
   belongs_to :job
 
-  # Validations
-  validates :triggered, presence: true
-
   def dispatch!
     # 1) Don't perform an action if it has already been performed on the rising edge trigger
     # 2) Only perform the dispatch if the event_receiver's trigger condition has been met
-    return if triggered || !event_receiver.trigger_condition_met?
+    return if triggered || !event_receiver.trigger_condition_met?(job)
 
     # Run each of the event actions corresponding to the job
     event_receiver.event_actions.each(&:run!)
 
     # Set the record to be triggered
-    self.triggered = true
+    update(triggered: true)
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -2,14 +2,14 @@
 
 class Job < ApplicationRecord
   # Callbacks
-  after_create :make_channel, :create_event_dispatcher!
+  after_create :make_channel, :create_event_dispatchers!
   before_save :default_values, :send_email
 
   # Associations
   belongs_to :worker
   belongs_to :job_type
   has_one :user, through: :worker
-  has_one :event_dispatcher, dependent: :destroy
+  has_many :event_dispatchers, dependent: :destroy
 
   # Validations
   validates :status, inclusion: { in: %w(DISPATCHED UNDEFINED ERROR NORMAL\ EXECUTION) }
@@ -47,7 +47,6 @@ class Job < ApplicationRecord
     SQL
   end
 
-  private
 
   def make_channel
     channel.make_private
@@ -62,10 +61,10 @@ class Job < ApplicationRecord
     ErrorMailer.email(self).deliver
   end
 
-  def create_event_dispatcher!
+  def create_event_dispatchers!
     # If the event_receiver does not exist, it will be updated when the event_receiver is created
     job_type.event_receivers.each do |receiver|
-      EventDispatcher.new(event_receiver: receiver, job: self)
+      event_dispatchers.create(event_receiver: receiver)
     end
   end
 end

--- a/app/models/regex_receiver.rb
+++ b/app/models/regex_receiver.rb
@@ -4,6 +4,6 @@ class RegexReceiver < EventReceiver
   validates :stream, inclusion: { in: %w(stdout stderr) }
 
   def trigger_condition_met?(job)
-    @trigger_condition_met ||= job.read_attribute(stream) =~ regex
+    @trigger_condition_met ||= job.read_attribute(stream) =~ Regexp.new(regex)
   end
 end

--- a/app/models/spawn_job.rb
+++ b/app/models/spawn_job.rb
@@ -12,7 +12,7 @@ class SpawnJob < EventAction
     if worker
       Job.create(job_type: job_type, worker: worker, status: "DISPATCHED")
     else
-      ScheduledWorker.perform_at(Worker::RETRY_TIME.from_now, id)
+      ScheduledWorker.perform_at(Worker::RETRY_TIME.from_now, event_receiver.id)
     end
   end
 end

--- a/app/models/spawn_job.rb
+++ b/app/models/spawn_job.rb
@@ -8,6 +8,11 @@
 #
 class SpawnJob < EventAction
   def run!
-    Job.new(job_type: job_type, worker: user.workers.assignment_order.first, status: "DISPATCHED")
+    worker = user.workers.assignment_order.first
+    if worker
+      Job.create(job_type: job_type, worker: worker, status: "DISPATCHED")
+    else
+      ScheduledWorker.perform_at(Worker::RETRY_TIME.from_now, id)
+    end
   end
 end

--- a/app/views/event_actions/_event_action.json.jbuilder
+++ b/app/views/event_actions/_event_action.json.jbuilder
@@ -1,2 +1,1 @@
-json.extract! event_action, :id, :event_receiver_id, :job_type, :email_address, :webhook_url, :webhook_body, :created_at, :updated_at
-json.url event_action_url(event_action, format: :json)
+json.extract! event_action, :id, :type, :event_receiver_id, :job_type_id, :email_address, :webhook_url, :webhook_body, :created_at, :updated_at

--- a/app/views/event_receivers/_event_receiver.json.jbuilder
+++ b/app/views/event_receivers/_event_receiver.json.jbuilder
@@ -1,1 +1,4 @@
-json.extract! event_receiver, :id, :type, :start_time, :interval, :job_type_id, :regex, :return_code, :stream, :created_at, :updated_at, :event_actions
+json.extract! event_receiver, :id, :type, :start_time, :interval, :job_type_id, :regex, :return_code, :stream, :created_at, :updated_at
+json.event_actions do
+  json.array! event_receiver.event_actions, partial: 'event_actions/event_action', as: :event_action
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,14 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: 'users/sessions'
   }
+
   resources :event_actions
+  # use the same controller for the EventAction subtypes
+  resources :spawn_jobs, controller: :event_actions
+  resources :emails, controller: :event_actions
 
   resources :event_receivers
-  # Use the same controller for the Eventreceiver subtypes
+  # Use the same controller for the EventReceiver subtypes
   resources :scheduled_receivers, controller: :event_receivers
   resources :interval_receivers, controller: :event_receivers
   resources :regex_receivers, controller: :event_receivers


### PR DESCRIPTION
Fixes:
- Match `type` values in frontend and backend
- Make requests to json endpoints so the response can actually be parsed
- Change the jbuilder files to render event actions properly
- Fix typos and missing params in ruby method calls
- Use `create()` and `update()` instead of `new` and `=` to ensure model changes get committed to the database instead of staying in memory
- Wrap the regex string in the `Regexp` class so the match operator works