### PR TITLE
Added pure virtual method to event_receiver to denote it must be overridden by derived concretions.

### DIFF
--- a/app/models/event_receiver.rb
+++ b/app/models/event_receiver.rb
@@ -14,6 +14,11 @@ class EventReceiver < ApplicationRecord
   validate :owned_job_type?
   accepts_nested_attributes_for :event_actions
 
+  # Pure virtual method, overridden by derived concretions
+  def trigger_condition_met?(_job)
+    raise NotImplementedError, "EventReceiver::trigger_condition_met!(job) is a pure virtual method."
+  end
+
   def owned_job_type?
     return unless job_type && job_type.user != user
     errors.add(:job_type, "must be one of your jobs")


### PR DESCRIPTION
### Changes

- Adds the pure virtual method `trigger_condition_met?(job)` to the abstract `EventReceiver` class.

### Notes

- I must have missed this when I was originally writing the interface, because without implementing the `trigger_condition_met?(job)` method it's not a valid receiver, and won't work in the context we want to use it in.