### PR TITLE
Add email body, fix regex bug

### DIFF
--- a/app/controllers/job_connection_controller.rb
+++ b/app/controllers/job_connection_controller.rb
@@ -32,6 +32,7 @@ class JobConnectionController < WebsocketRails::BaseController
   end
 
   def dispatch_job_events!
+    job.reload
     job.event_dispatchers.each(&:dispatch!)
   end
 end

--- a/app/javascript/packs/event_actions.jsx
+++ b/app/javascript/packs/event_actions.jsx
@@ -8,7 +8,7 @@ class EventAction extends React.Component {
     this.state = {};
 
     this.DATA_FIELDS =
-      ['email_address', 'webhook_url', 'webhook_body', 'job_type_id', 'type'];
+      ['email_address', 'email_body', 'webhook_url', 'webhook_body', 'job_type_id', 'type'];
 
     [
       'save',
@@ -47,8 +47,9 @@ class EventAction extends React.Component {
   nullState() {
     return {
       loading: false,
-      type: 'EmailAction',
+      type: 'Email',
       email_address: null,
+      email_body: null,
       webhook_url: null,
       webhook_body: null,
       job_type_id: null
@@ -99,12 +100,16 @@ class EventAction extends React.Component {
   renderForm() {
     switch (this.props.type) {
       case 'Email':
-        return (
-          <div className='field'>
-            <label>Email</label>
+        return [
+          <div key='1' className='field'>
+            <label>Address</label>
             <input type='text' value={this.props.email_address || ''} onChange={this.updateEmailAddress} />
+          </div>,
+          <div key='2' className='field'>
+            <label>Body</label>
+            <textarea value={this.props.email_body || ''} onChange={this.updateEmailBody} />
           </div>
-        );
+        ];
       case 'Webhook':
         return [
           <div key='1' className='field'>

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class ErrorMailer < ApplicationMailer
-  def email(job)
-    @job = job
-    Rails.logger.info "Sending out error email for job #{job&.id}."
-    mail(to: "andrewrobertmcburney@gmail.com", subject: "Error in job execution.")
-  end
-end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class NotificationMailer < ApplicationMailer
+  def email(address, body)
+    Rails.logger.info "Sending email to #{address}: #{body}"
+    mail(
+      to: address,
+      subject: "Message from a Conductor job",
+      body: body
+    )
+  end
+end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -8,6 +8,6 @@
 #
 class Email < EventAction
   def run!
-    ErrorMailer.email(job_type).deliver
+    NotificationMailer.email(email_address, email_body).deliver
   end
 end

--- a/app/models/event_action.rb
+++ b/app/models/event_action.rb
@@ -10,7 +10,7 @@ class EventAction < ApplicationRecord
   validate  :owned_job_type?
   validates :type, presence: true
 
-  PROPERTIES = %i(job_type_id email_address webhook_url webhook_body type)
+  PROPERTIES = %i(job_type_id email_address email_body webhook_url webhook_body type)
 
   def run!
     raise NotImplementedError, "EventAction::run!(user) is a pure virtual method."

--- a/app/views/event_actions/_event_action.json.jbuilder
+++ b/app/views/event_actions/_event_action.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! event_action, :id, :type, :event_receiver_id, :job_type_id, :email_address, :webhook_url, :webhook_body, :created_at, :updated_at
+json.extract! event_action, :id, :type, :event_receiver_id, :job_type_id, :email_address, :email_body, :webhook_url, :webhook_body, :created_at, :updated_at

--- a/db/migrate/20171114232131_add_email_body_to_event_action.rb
+++ b/db/migrate/20171114232131_add_email_body_to_event_action.rb
@@ -1,0 +1,5 @@
+class AddEmailBodyToEventAction < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_actions, :email_body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171105131300) do
+ActiveRecord::Schema.define(version: 20171114232131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20171105131300) do
     t.datetime "updated_at",                   null: false
     t.integer  "job_type_id"
     t.string   "type",              limit: 20, null: false
+    t.text     "email_body"
     t.index ["event_receiver_id"], name: "index_event_actions_on_event_receiver_id", using: :btree
     t.index ["job_type_id"], name: "index_event_actions_on_job_type_id", using: :btree
   end


### PR DESCRIPTION
- Renames the error mailer to just be the email notification mailer
- lets you specify the body
- Fixes a bug where event dispatchers weren't checking the updated stream value, needed to be reloaded from the db (this doesn't happen automatically for hardcoded SQL statements I guess)